### PR TITLE
feat(deps): bundle postcss

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,9 +27,6 @@
   "simple-git-hooks": {
     "pre-commit": "npm run lint:write"
   },
-  "dependencies": {
-    "postcss": "^8.4.47"
-  },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
     "@playwright/test": "^1.48.2",
@@ -37,6 +34,7 @@
     "@rslib/core": "^0.0.16",
     "@types/node": "^22.9.0",
     "playwright": "^1.48.2",
+    "postcss": "^8.4.47",
     "simple-git-hooks": "^2.11.1",
     "tailwindcss": "^3.4.14",
     "typescript": "^5.6.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,10 +7,6 @@ settings:
 importers:
 
   .:
-    dependencies:
-      postcss:
-        specifier: ^8.4.47
-        version: 8.4.47
     devDependencies:
       '@biomejs/biome':
         specifier: ^1.9.4
@@ -30,6 +26,9 @@ importers:
       playwright:
         specifier: ^1.48.2
         version: 1.48.2
+      postcss:
+        specifier: ^8.4.47
+        version: 8.4.47
       simple-git-hooks:
         specifier: ^2.11.1
         version: 2.11.1


### PR DESCRIPTION
We move `postcss` from `dependencies` to `devDependencies` to allow
Rslib to bundle the it into `dist/`.
