### PR TITLE
feat: support custom postcss options

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,8 @@
-import type { RsbuildPlugin } from '@rsbuild/core';
+import type {
+  PostCSSLoaderOptions,
+  RsbuildPlugin,
+  Rspack,
+} from '@rsbuild/core';
 
 import { TailwindRspackPlugin } from './TailwindCSSRspackPlugin.js';
 
@@ -58,13 +62,45 @@ export const pluginTailwindCSS = (
   name: 'rsbuild:tailwindcss',
 
   setup(api) {
+    let postcssOptions: Exclude<
+      PostCSSLoaderOptions['postcssOptions'],
+      (loaderContext: Rspack.LoaderContext) => void
+    >;
+
+    api.modifyRsbuildConfig({
+      order: 'post',
+      handler(config, { mergeRsbuildConfig }) {
+        return mergeRsbuildConfig(config, {
+          tools: {
+            postcss(config) {
+              if (typeof config.postcssOptions === 'function') {
+                throw new Error(
+                  'pluginTailwindCSS does not support using `tools.postcss` as function',
+                );
+              }
+              if (config.postcssOptions) {
+                // Remove `tailwindcss` from `postcssOptions`
+                // to avoid `@tailwind` being transformed by `postcss-loader`.
+                config.postcssOptions.plugins =
+                  config.postcssOptions.plugins?.filter(
+                    (p) =>
+                      'postcssPlugin' in p && p.postcssPlugin !== 'tailwindcss',
+                  ) ?? [];
+                postcssOptions = config.postcssOptions;
+              }
+            },
+          },
+        });
+      },
+    });
+
     api.modifyBundlerChain({
       order: 'post',
       handler(chain) {
         chain
           .plugin('tailwindcss')
           .use(TailwindRspackPlugin, [
-            { config: options.config ?? 'tailwind.config.js' },
+            { config: options.config ?? 'tailwind.config.js', postcssOptions },
           ]);
       },
     });

--- a/test/postcss-config/flex-to-grid.js
+++ b/test/postcss-config/flex-to-grid.js
@@ -1,0 +1,15 @@
+/**
+ * @returns {import('postcss').AcceptedPlugin}
+ */
+export default function () {
+  return {
+    postcssPlugin: 'flex-to-grid',
+    Declaration: {
+      display(decl) {
+        if (decl.value === 'flex') {
+          decl.value = 'grid';
+        }
+      },
+    },
+  };
+}

--- a/test/postcss-config/index.test.ts
+++ b/test/postcss-config/index.test.ts
@@ -1,0 +1,35 @@
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { expect, test } from '@playwright/test';
+import { createRsbuild } from '@rsbuild/core';
+import { pluginTailwindCSS } from '../../src';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+test('should build with postcss.config.js', async ({ page }) => {
+  const rsbuild = await createRsbuild({
+    cwd: __dirname,
+    rsbuildConfig: {
+      plugins: [pluginTailwindCSS()],
+    },
+  });
+
+  await rsbuild.build();
+  const { server, urls } = await rsbuild.preview();
+
+  await page.goto(urls[0]);
+
+  const display = await page.evaluate(() => {
+    const el = document.getElementById('test');
+
+    if (!el) {
+      throw new Error('#test not found');
+    }
+
+    return window.getComputedStyle(el).getPropertyValue('display');
+  });
+
+  expect(display).toBe('grid');
+
+  await server.close();
+});

--- a/test/postcss-config/postcss.config.js
+++ b/test/postcss-config/postcss.config.js
@@ -1,0 +1,6 @@
+import tailwindcss from 'tailwindcss';
+import flexToGrid from './flex-to-grid';
+
+export default {
+  plugins: [tailwindcss(), flexToGrid()],
+};

--- a/test/postcss-config/src/index.js
+++ b/test/postcss-config/src/index.js
@@ -1,0 +1,11 @@
+import 'tailwindcss/utilities.css';
+
+function className() {
+  return 'flex';
+}
+
+const root = document.getElementById('root');
+const element = document.createElement('div');
+element.id = 'test';
+element.className = className();
+root.appendChild(element);

--- a/test/tools-postcss/flex-to-grid.js
+++ b/test/tools-postcss/flex-to-grid.js
@@ -1,0 +1,15 @@
+/**
+ * @returns {import('postcss').AcceptedPlugin}
+ */
+export default function () {
+  return {
+    postcssPlugin: 'flex-to-grid',
+    Declaration: {
+      display(decl) {
+        if (decl.value === 'flex') {
+          decl.value = 'grid';
+        }
+      },
+    },
+  };
+}

--- a/test/tools-postcss/index.test.ts
+++ b/test/tools-postcss/index.test.ts
@@ -1,0 +1,80 @@
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { expect, test } from '@playwright/test';
+import { createRsbuild } from '@rsbuild/core';
+import { pluginTailwindCSS } from '../../src';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+test('should build with tools.postcss with tailwindcss', async ({ page }) => {
+  const { default: tailwindcss } = await import('tailwindcss');
+  const rsbuild = await createRsbuild({
+    cwd: __dirname,
+    rsbuildConfig: {
+      plugins: [pluginTailwindCSS()],
+      tools: {
+        postcss: {
+          postcssOptions: {
+            plugins: [tailwindcss()],
+          },
+        },
+      },
+    },
+  });
+
+  await rsbuild.build();
+  const { server, urls } = await rsbuild.preview();
+
+  await page.goto(urls[0]);
+
+  const display = await page.evaluate(() => {
+    const el = document.getElementById('test');
+
+    if (!el) {
+      throw new Error('#test not found');
+    }
+
+    return window.getComputedStyle(el).getPropertyValue('display');
+  });
+
+  expect(display).toBe('flex');
+
+  await server.close();
+});
+
+test('should build with tools.postcss with custom plugin', async ({ page }) => {
+  const { default: tailwindcss } = await import('tailwindcss');
+  const { default: flexToGrid } = await import('./flex-to-grid.js');
+  const rsbuild = await createRsbuild({
+    cwd: __dirname,
+    rsbuildConfig: {
+      plugins: [pluginTailwindCSS()],
+      tools: {
+        postcss: {
+          postcssOptions: {
+            plugins: [flexToGrid()],
+          },
+        },
+      },
+    },
+  });
+
+  await rsbuild.build();
+  const { server, urls } = await rsbuild.preview();
+
+  await page.goto(urls[0]);
+
+  const display = await page.evaluate(() => {
+    const el = document.getElementById('test');
+
+    if (!el) {
+      throw new Error('#test not found');
+    }
+
+    return window.getComputedStyle(el).getPropertyValue('display');
+  });
+
+  expect(display).toBe('grid');
+
+  await server.close();
+});

--- a/test/tools-postcss/src/index.js
+++ b/test/tools-postcss/src/index.js
@@ -1,0 +1,11 @@
+import 'tailwindcss/utilities.css';
+
+function className() {
+  return 'flex';
+}
+
+const root = document.getElementById('root');
+const element = document.createElement('div');
+element.id = 'test';
+element.className = className();
+root.appendChild(element);


### PR DESCRIPTION
## For Rspack plugin:

We add a new option `postcssOptions` which will be passed to `postcss()` and `postcss().process()`.
.
## For Rsbuild plugin:

We automatically read postcss options from Rsbuild config. It will be auto-loaded and merged from `postcss.config.js` and `tools.postcss`.

We also removes `tailwindcss` from `postcssOptions.plugins` to avoid `@tailwind` being transformed by `postcss-loader`.

close: #8
