### PR TITLE
chore: rename to `rsbuild-plugin-tailwindcss`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# @rsbuild/plugin-tailwindcss
+# rsbuild-plugin-tailwindcss
 
 An Rsbuild plugin to integrate with [Tailwind CSS](https://tailwindcss.com/) V3.
 
 <p>
-  <a href="https://npmjs.com/package/@rsbuild/plugin-tailwindcss">
-   <img src="https://img.shields.io/npm/v/@rsbuild/plugin-tailwindcss?style=flat-square&colorA=564341&colorB=EDED91" alt="npm version" />
+  <a href="https://npmjs.com/package/rsbuild-plugin-tailwindcss">
+   <img src="https://img.shields.io/npm/v/rsbuild-plugin-tailwindcss?style=flat-square&colorA=564341&colorB=EDED91" alt="npm version" />
   </a>
   <img src="https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square&colorA=564341&colorB=EDED91" alt="license" />
-  <a href="https://npmcharts.com/compare/@rsbuild/plugin-tailwindcss?minimal=true"><img src="https://img.shields.io/npm/dm/@rsbuild/plugin-tailwindcss.svg?style=flat-square&colorA=564341&colorB=EDED91" alt="downloads" /></a>
+  <a href="https://npmcharts.com/compare/rsbuild-plugin-tailwindcss?minimal=true"><img src="https://img.shields.io/npm/dm/rsbuild-plugin-tailwindcss.svg?style=flat-square&colorA=564341&colorB=EDED91" alt="downloads" /></a>
 </p>
 
 ## Usage
@@ -15,14 +15,14 @@ An Rsbuild plugin to integrate with [Tailwind CSS](https://tailwindcss.com/) V3.
 Install:
 
 ```bash
-npm add @rsbuild/plugin-tailwindcss -D
+npm add rsbuild-plugin-tailwindcss -D
 ```
 
 Add plugin to your `rsbuild.config.ts`:
 
 ```ts
 // rsbuild.config.ts
-import { pluginTailwindCSS } from "@rsbuild/plugin-tailwindcss";
+import { pluginTailwindCSS } from "rsbuild-plugin-tailwindcss";
 
 export default {
   plugins: [pluginTailwindCSS()],

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@rsbuild/plugin-tailwindcss",
+  "name": "rsbuild-plugin-tailwindcss",
   "version": "0.0.0",
   "repository": "https://github.com/rspack-contrib/rsbuild-plugin-tailwindcss",
   "license": "MIT",
@@ -40,7 +40,7 @@
     "typescript": "^5.6.3"
   },
   "peerDependencies": {
-    "@rsbuild/core": "1.x",
+    "@rsbuild/core": "^1.1.0",
     "tailwindcss": "^3"
   },
   "peerDependenciesMeta": {

--- a/src/TailwindCSSRspackPlugin.ts
+++ b/src/TailwindCSSRspackPlugin.ts
@@ -24,7 +24,7 @@ interface TailwindRspackPluginOptions {
    * import path from 'node:path'
    * import { fileURLToPath } from 'node:url'
    *
-   * import { TailwindRspackPlugin } from '@rsbuild/plugin-tailwindcss'
+   * import { TailwindRspackPlugin } from 'rsbuild-plugin-tailwindcss'
    *
    * const __dirname = path.dirname(fileURLToPath(import.meta.url))
    *
@@ -43,7 +43,7 @@ interface TailwindRspackPluginOptions {
    *
    * ```js
    * // rspack.config.js
-   * import { TailwindRspackPlugin } from '@rsbuild/plugin-tailwindcss'
+   * import { TailwindRspackPlugin } from 'rsbuild-plugin-tailwindcss'
    *
    * export default {
    *   plugins: [
@@ -65,7 +65,7 @@ interface TailwindRspackPluginOptions {
    *
    * ```js
    * // rspack.config.js
-   * import { TailwindRspackPlugin } from '@rsbuild/plugin-tailwindcss'
+   * import { TailwindRspackPlugin } from 'rsbuild-plugin-tailwindcss'
    *
    * export default {
    *   plugins: [

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,7 @@ export type PluginTailwindCSSOptions = {
    * import path from 'node:path'
    * import { fileURLToPath } from 'node:url'
    *
-   * import { pluginTailwindCSS } from '@rsbuild/plugin-tailwindcss'
+   * import { pluginTailwindCSS } from 'rsbuild-plugin-tailwindcss'
    *
    * const __dirname = path.dirname(fileURLToPath(import.meta.url))
    *


### PR DESCRIPTION
Also, change the `peerDependencies['@rsbuild/core']` to ^1.1.0 since we need [`module.modules`](https://github.com/web-infra-dev/rspack/pull/8192) to work, which has been released in Rspack v1.1.0.