### PR TITLE
feat: implement `include` and `exclude` option

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
     "@playwright/test": "^1.48.2",
+    "@rollup/pluginutils": "^5.1.3",
     "@rsbuild/core": "^1.1.0",
     "@rslib/core": "^0.0.16",
     "@types/node": "^22.9.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@playwright/test':
         specifier: ^1.48.2
         version: 1.48.2
+      '@rollup/pluginutils':
+        specifier: ^5.1.3
+        version: 5.1.3
       '@rsbuild/core':
         specifier: ^1.1.0
         version: 1.1.0
@@ -154,6 +157,15 @@ packages:
     resolution: {integrity: sha512-54w1xCWfXuax7dz4W2M9uw0gDyh+ti/0K/MxcCUxChFh37kkdxPdfZDw5QBbuPUJHr1CiHJ1hXgSs+GgeQc5Zw==}
     engines: {node: '>=18'}
     hasBin: true
+
+  '@rollup/pluginutils@5.1.3':
+    resolution: {integrity: sha512-Pnsb6f32CD2W3uCaLZIzDmeFyQ2b8UWMFI7xtwUezpcGBDVDW6y9XgAWIlARiGAo6eNF5FK5aQTr0LFyNyqq5A==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
 
   '@rsbuild/core@1.0.19':
     resolution: {integrity: sha512-63DAPvYfRBoUrb51BUPb4Xoqx48MHQ0yLcmnCiqZGpMeKYtTWzD+lyx5va4cr9qvdnIFTAX2BMuYC/j5iSrtTA==}
@@ -299,6 +311,9 @@ packages:
   '@swc/helpers@0.5.13':
     resolution: {integrity: sha512-UoKGxQ3r5kYI9dALKJapMmuK+1zWM/H17Z1+iwnNmzcJRnfFuevZs375TA5rW31pu4BS4NoSy1fRsexDXfWn5w==}
 
+  '@types/estree@1.0.6':
+    resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
+
   '@types/node@22.9.0':
     resolution: {integrity: sha512-vuyHg81vvWA1Z1ELfvLko2c8f34gyA0zaic0+Rllc5lbCnbSyuvb2Oxpm6TAUAC/2xZN3QGqxBNggD1nNR2AfQ==}
 
@@ -393,6 +408,9 @@ packages:
 
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
   fast-glob@3.3.2:
     resolution: {integrity: sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==}
@@ -851,6 +869,12 @@ snapshots:
     dependencies:
       playwright: 1.48.2
 
+  '@rollup/pluginutils@5.1.3':
+    dependencies:
+      '@types/estree': 1.0.6
+      estree-walker: 2.0.2
+      picomatch: 4.0.2
+
   '@rsbuild/core@1.0.19':
     dependencies:
       '@rspack/core': 1.0.14(@swc/helpers@0.5.13)
@@ -979,6 +1003,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@types/estree@1.0.6': {}
+
   '@types/node@22.9.0':
     dependencies:
       undici-types: 6.19.8
@@ -1059,6 +1085,8 @@ snapshots:
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
+
+  estree-walker@2.0.2: {}
 
   fast-glob@3.3.2:
     dependencies:

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,8 +5,11 @@ import type {
 } from '@rsbuild/core';
 
 import { TailwindRspackPlugin } from './TailwindCSSRspackPlugin.js';
+import type { FilterPattern } from './TailwindCSSRspackPlugin.js';
 
-export type PluginTailwindCSSOptions = {
+export type { FilterPattern };
+
+export interface PluginTailwindCSSOptions {
   /**
    * The path to the configuration of Tailwind CSS.
    *
@@ -54,7 +57,62 @@ export type PluginTailwindCSSOptions = {
    * ```
    */
   config?: string;
-};
+
+  /**
+   * The modules to be excluded using `picomatch` patterns.
+   *
+   * If {@link include} is omitted or empty,
+   * all modules that do not match any of the {@link exclude} patterns will be included.
+   * Otherwise, only modules that match one or more of the {@link include} patterns
+   * and do not match any of the {@link exclude} patterns will be included.
+   *
+   * @example
+   *
+   * ```js
+   * // rsbuild.config.ts
+   * import { pluginTailwindCSS } from '@byted-lynx/plugin-tailwindcss'
+   *
+   * export default {
+   *   plugins: [
+   *     pluginTailwindCSS({
+   *       exclude: [
+   *         './src/store/**',
+   *         /[\\/]node_modules[\\/]/,
+   *       ],
+   *     }),
+   *   ],
+   * }
+   * ```
+   */
+  exclude?: FilterPattern | undefined;
+
+  /**
+   * The modules to be included using `picomatch` patterns.
+   *
+   * If {@link include} is omitted or empty,
+   * all modules that do not match any of the {@link exclude} patterns will be included.
+   * Otherwise, only modules that match one or more of the {@link include} patterns
+   * and do not match any of the {@link exclude} patterns will be included.
+   *
+   * @example
+   *
+   * ```js
+   * // rsbuild.config.ts
+   * import { pluginTailwindCSS } from '@byted-lynx/plugin-tailwindcss'
+   *
+   * export default {
+   *   plugins: [
+   *     pluginTailwindCSS({
+   *       include: [
+   *         /\.[jt]sx?/,
+   *       ],
+   *     }),
+   *   ],
+   * }
+   * ```
+   */
+  include?: FilterPattern | undefined;
+}
 
 export const pluginTailwindCSS = (
   options: PluginTailwindCSSOptions = {},
@@ -97,11 +155,14 @@ export const pluginTailwindCSS = (
     api.modifyBundlerChain({
       order: 'post',
       handler(chain) {
-        chain
-          .plugin('tailwindcss')
-          .use(TailwindRspackPlugin, [
-            { config: options.config ?? 'tailwind.config.js', postcssOptions },
-          ]);
+        chain.plugin('tailwindcss').use(TailwindRspackPlugin, [
+          {
+            config: options.config ?? 'tailwind.config.js',
+            include: options.include,
+            exclude: options.exclude,
+            postcssOptions,
+          },
+        ]);
       },
     });
   },

--- a/test/exclude-include/index.test.ts
+++ b/test/exclude-include/index.test.ts
@@ -1,0 +1,100 @@
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { expect, test } from '@playwright/test';
+import { createRsbuild } from '@rsbuild/core';
+
+import { getRandomPort } from '../helper';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+test('should build with included and excluded modules', async ({ page }) => {
+  const { pluginTailwindCSS } = await import('../../src');
+  const rsbuild = await createRsbuild({
+    cwd: __dirname,
+    rsbuildConfig: {
+      plugins: [
+        pluginTailwindCSS({
+          include: './src/*.{js,jsx}',
+          exclude: './src/exclude.js',
+        }),
+      ],
+      server: {
+        port: getRandomPort(),
+      },
+    },
+  });
+
+  await rsbuild.build();
+  const { server, urls } = await rsbuild.preview();
+
+  await page.goto(urls[0]);
+
+  const display = await page.evaluate(() => {
+    const el = document.getElementById('test');
+
+    if (!el) {
+      throw new Error('#test not found');
+    }
+
+    return window.getComputedStyle(el).getPropertyValue('display');
+  });
+
+  expect(display).toBe('flex');
+
+  // Exclude
+  {
+    const textAlign = await page.evaluate(() => {
+      const el = document.getElementById('exclude');
+
+      if (!el) {
+        throw new Error('#exclude not found');
+      }
+
+      return window.getComputedStyle(el).getPropertyValue('text-align');
+    });
+
+    expect(textAlign).not.toBe('center');
+
+    // The `not-exclude.js` imported by `exclude.js` should not be excluded.
+    const paddingTop = await page.evaluate(() => {
+      const el = document.getElementById('not-exclude');
+
+      if (!el) {
+        throw new Error('#not-exclude not found');
+      }
+
+      return window.getComputedStyle(el).getPropertyValue('padding-top');
+    });
+
+    expect(paddingTop).toBe('16px');
+  }
+
+  // Include
+  {
+    const textAlign = await page.evaluate(() => {
+      const el = document.getElementById('not-include');
+
+      if (!el) {
+        throw new Error('#not-include not found');
+      }
+
+      return window.getComputedStyle(el).getPropertyValue('text-align');
+    });
+
+    expect(textAlign).not.toBe('center');
+
+    // The `include.js` imported by `not-include.ts` should be included.
+    const paddingTop = await page.evaluate(() => {
+      const el = document.getElementById('include');
+
+      if (!el) {
+        throw new Error('#include not found');
+      }
+
+      return window.getComputedStyle(el).getPropertyValue('padding-top');
+    });
+
+    expect(paddingTop).toBe('16px');
+  }
+  await server.close();
+});

--- a/test/exclude-include/src/exclude.js
+++ b/test/exclude-include/src/exclude.js
@@ -1,0 +1,12 @@
+// The `not-exclude.js` imported by `exclude.js` should not be excluded.
+import './not-exclude.js';
+
+function className() {
+  return 'text-center';
+}
+
+const root = document.getElementById('root');
+const element = document.createElement('div');
+element.id = 'exclude';
+element.className = className();
+root.appendChild(element);

--- a/test/exclude-include/src/include.jsx
+++ b/test/exclude-include/src/include.jsx
@@ -1,0 +1,9 @@
+function className() {
+  return 'pt-4';
+}
+
+const root = document.getElementById('root');
+const element = document.createElement('div');
+element.id = 'include';
+element.className = className();
+root.appendChild(element);

--- a/test/exclude-include/src/index.js
+++ b/test/exclude-include/src/index.js
@@ -1,0 +1,14 @@
+import 'tailwindcss/utilities.css';
+
+import './exclude.js';
+import './not-include.ts';
+
+function className() {
+  return 'flex';
+}
+
+const root = document.getElementById('root');
+const element = document.createElement('div');
+element.id = 'test';
+element.className = className();
+root.appendChild(element);

--- a/test/exclude-include/src/not-exclude.js
+++ b/test/exclude-include/src/not-exclude.js
@@ -1,0 +1,9 @@
+function className() {
+  return 'pt-4';
+}
+
+const root = document.getElementById('root');
+const element = document.createElement('div');
+element.id = 'not-exclude';
+element.className = className();
+root.appendChild(element);

--- a/test/exclude-include/src/not-include.ts
+++ b/test/exclude-include/src/not-include.ts
@@ -1,0 +1,12 @@
+// The `include.jsx` imported by `not-include.ts` should not be excluded.
+import './include.jsx';
+
+function className() {
+  return 'text-center';
+}
+
+const root = document.getElementById('root');
+const element = document.createElement('div');
+element.id = 'not-include';
+element.className = className();
+root?.appendChild(element);

--- a/test/exclude/index.test.ts
+++ b/test/exclude/index.test.ts
@@ -1,0 +1,69 @@
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { expect, test } from '@playwright/test';
+import { createRsbuild } from '@rsbuild/core';
+
+import { getRandomPort } from '../helper';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+test('should build with excluded modules', async ({ page }) => {
+  const { pluginTailwindCSS } = await import('../../src');
+  const rsbuild = await createRsbuild({
+    cwd: __dirname,
+    rsbuildConfig: {
+      plugins: [
+        pluginTailwindCSS({
+          exclude: ['./src/exclude.js'],
+        }),
+      ],
+      server: {
+        port: getRandomPort(),
+      },
+    },
+  });
+
+  await rsbuild.build();
+  const { server, urls } = await rsbuild.preview();
+
+  await page.goto(urls[0]);
+
+  const display = await page.evaluate(() => {
+    const el = document.getElementById('test');
+
+    if (!el) {
+      throw new Error('#test not found');
+    }
+
+    return window.getComputedStyle(el).getPropertyValue('display');
+  });
+
+  expect(display).toBe('flex');
+
+  const textAlign = await page.evaluate(() => {
+    const el = document.getElementById('exclude');
+
+    if (!el) {
+      throw new Error('#exclude not found');
+    }
+
+    return window.getComputedStyle(el).getPropertyValue('text-align');
+  });
+
+  expect(textAlign).not.toBe('center');
+
+  // The `not-exclude.js` imported by `exclude.js` should not be excluded.
+  const paddingTop = await page.evaluate(() => {
+    const el = document.getElementById('not-exclude');
+
+    if (!el) {
+      throw new Error('#not-exclude not found');
+    }
+
+    return window.getComputedStyle(el).getPropertyValue('padding-top');
+  });
+
+  expect(paddingTop).toBe('16px');
+
+  await server.close();
+});

--- a/test/exclude/src/exclude.js
+++ b/test/exclude/src/exclude.js
@@ -1,0 +1,12 @@
+// The `not-exclude.js` imported by `exclude.js` should not be excluded.
+import './not-exclude.js';
+
+function className() {
+  return 'text-center';
+}
+
+const root = document.getElementById('root');
+const element = document.createElement('div');
+element.id = 'exclude';
+element.className = className();
+root.appendChild(element);

--- a/test/exclude/src/index.js
+++ b/test/exclude/src/index.js
@@ -1,0 +1,13 @@
+import 'tailwindcss/utilities.css';
+
+import './exclude.js';
+
+function className() {
+  return 'flex';
+}
+
+const root = document.getElementById('root');
+const element = document.createElement('div');
+element.id = 'test';
+element.className = className();
+root.appendChild(element);

--- a/test/exclude/src/not-exclude.js
+++ b/test/exclude/src/not-exclude.js
@@ -1,0 +1,9 @@
+function className() {
+  return 'pt-4';
+}
+
+const root = document.getElementById('root');
+const element = document.createElement('div');
+element.id = 'not-exclude';
+element.className = className();
+root.appendChild(element);

--- a/test/include/index.test.ts
+++ b/test/include/index.test.ts
@@ -1,0 +1,69 @@
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { expect, test } from '@playwright/test';
+import { createRsbuild } from '@rsbuild/core';
+
+import { getRandomPort } from '../helper';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+test('should build with included modules', async ({ page }) => {
+  const { pluginTailwindCSS } = await import('../../src');
+  const rsbuild = await createRsbuild({
+    cwd: __dirname,
+    rsbuildConfig: {
+      plugins: [
+        pluginTailwindCSS({
+          include: './src/*.{js,jsx}',
+        }),
+      ],
+      server: {
+        port: getRandomPort(),
+      },
+    },
+  });
+
+  await rsbuild.build();
+  const { server, urls } = await rsbuild.preview();
+
+  await page.goto(urls[0]);
+
+  const display = await page.evaluate(() => {
+    const el = document.getElementById('test');
+
+    if (!el) {
+      throw new Error('#test not found');
+    }
+
+    return window.getComputedStyle(el).getPropertyValue('display');
+  });
+
+  expect(display).toBe('flex');
+
+  const textAlign = await page.evaluate(() => {
+    const el = document.getElementById('not-include');
+
+    if (!el) {
+      throw new Error('#not-include not found');
+    }
+
+    return window.getComputedStyle(el).getPropertyValue('text-align');
+  });
+
+  expect(textAlign).not.toBe('center');
+
+  // The `include.js` imported by `not-include.ts` should be included.
+  const paddingTop = await page.evaluate(() => {
+    const el = document.getElementById('include');
+
+    if (!el) {
+      throw new Error('#include not found');
+    }
+
+    return window.getComputedStyle(el).getPropertyValue('padding-top');
+  });
+
+  expect(paddingTop).toBe('16px');
+
+  await server.close();
+});

--- a/test/include/src/include.jsx
+++ b/test/include/src/include.jsx
@@ -1,0 +1,9 @@
+function className() {
+  return 'pt-4';
+}
+
+const root = document.getElementById('root');
+const element = document.createElement('div');
+element.id = 'include';
+element.className = className();
+root.appendChild(element);

--- a/test/include/src/index.js
+++ b/test/include/src/index.js
@@ -1,0 +1,13 @@
+import 'tailwindcss/utilities.css';
+
+import './not-include.ts';
+
+function className() {
+  return 'flex';
+}
+
+const root = document.getElementById('root');
+const element = document.createElement('div');
+element.id = 'test';
+element.className = className();
+root.appendChild(element);

--- a/test/include/src/not-include.ts
+++ b/test/include/src/not-include.ts
@@ -1,0 +1,12 @@
+// The `include.jsx` imported by `not-include.ts` should not be excluded.
+import './include.jsx';
+
+function className() {
+  return 'text-center';
+}
+
+const root = document.getElementById('root');
+const element = document.createElement('div');
+element.id = 'not-include';
+element.className = className();
+root?.appendChild(element);


### PR DESCRIPTION
We add `exclude` and `include` in this patch to filter out the modules to be processed by Tailwind CSS.

### Details

We use the [`createFilter`](https://github.com/rollup/plugins/blob/master/packages/pluginutils/README.md#createfilter) from `@rollup/pluginutils` to deal with `include` and `exclude`.

> From `@rollup/pluginutils`
>
> A valid [picomatch](https://github.com/micromatch/picomatch#globbing-features) pattern, or array of patterns. If options.include is omitted or has zero length, filter will return true by default. Otherwise, an ID must match one or more of the picomatch patterns, and must not match any of the options.exclude patterns.
>
> Note that picomatch patterns are very similar to [minimatch](https://github.com/isaacs/minimatch#readme) patterns, and in most use cases, they are interchangeable. If you have more specific pattern matching needs, you can view [this comparison table](https://github.com/micromatch/picomatch#library-comparisons) to learn more about where the libraries differ.

Note that we are filtering modules one by one. So excluding a module will not exclude it's dependencies. E.g.:

```
foo.js(included)
| --> bar.js (excluded)
      | --> baz.js (included)
``` 

Even if `bar.js` is excluded, the `baz.js` it imports will be included and processed by Tailwind CSS.

### Related issue

close: #15 