### PR TITLE
feat: support tailwindcss v3.1.x and v3.2.y

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,6 @@ jobs:
         os: [ubuntu-latest, windows-latest]
         tailwindcss:
           - latest
-          - "3.3.0" # The first version that does support ESM.
           - "3.1.0" # The fist version that support `options.config`.
 
     # Steps represent a sequence of tasks that will be executed as part of the job

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,9 +41,9 @@ jobs:
 
       - name: Install tailwindcss@${{ matrix.tailwindcss }}
         if: ${{ matrix.tailwindcss }} != "latest"
-        # Tailwind CSS <= v3.4.0 does not have correct TypeScript definition.
-        # So we add a `|| echo 'Success'` to avoid `rslib build` failed.
-        run: pnpm add -D -w tailwindcss@${{ matrix.tailwindcss }} || echo 'Success'
+        # Tailwind CSS <= v3.4.0 does not have correct TypeScript definition, which will make `rslib build` fail.
+        continue-on-error: true 
+        run: pnpm add -D -w tailwindcss@${{ matrix.tailwindcss }}
 
       - name: Run Test
         run: pnpm run test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,9 @@ jobs:
 
       - name: Install tailwindcss@${{ matrix.tailwindcss }}
         if: ${{ matrix.tailwindcss }} != "latest"
-        run: pnpm add -D -w tailwindcss@${{ matrix.tailwindcss }}
+        # Tailwind CSS <= v3.4.0 does not have correct TypeScript definition.
+        # So we add a `|| echo 'Success'` to avoid `rslib build` failed.
+        run: pnpm add -D -w tailwindcss@${{ matrix.tailwindcss }} || echo 'Success'
 
       - name: Run Test
         run: pnpm run test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,8 @@ jobs:
         os: [ubuntu-latest, windows-latest]
         tailwindcss:
           - latest
-          - "3.2.7" # The lastest version that does not support ESM.
+          - "3.3.0" # The first version that does support ESM.
+          - "3.1.0" # The fist version that support `options.config`.
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,9 +14,13 @@ on:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
+    name: Test tailwindcss@${{ matrix.tailwindcss }} on ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
+        tailwindcss:
+          - latest
+          - "3.2.7" # The lastest version that does not support ESM.
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -34,6 +38,10 @@ jobs:
 
       - name: Install Dependencies
         run: pnpm install && npx playwright install
+
+      - name: Install tailwindcss@${{ matrix.tailwindcss }}
+        if: ${{ matrix.tailwindcss }} != "latest"
+        run: pnpm add -D -w tailwindcss@${{ matrix.tailwindcss }}
 
       - name: Run Test
         run: pnpm run test

--- a/package.json
+++ b/package.json
@@ -34,8 +34,10 @@
     "@rsbuild/core": "^1.1.0",
     "@rslib/core": "^0.0.16",
     "@types/node": "^22.9.0",
+    "@types/semver": "^7.5.8",
     "playwright": "^1.48.2",
     "postcss": "^8.4.47",
+    "semver": "^7.6.3",
     "simple-git-hooks": "^2.11.1",
     "tailwindcss": "^3.4.14",
     "typescript": "^5.6.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,7 +43,7 @@ importers:
         version: 2.11.1
       tailwindcss:
         specifier: ^3.4.14
-        version: 3.4.14
+        version: 3.4.15
       typescript:
         specifier: ^5.6.3
         version: 5.6.3
@@ -394,8 +394,8 @@ packages:
   core-js@3.39.0:
     resolution: {integrity: sha512-raM0ew0/jJUqkJ0E6e8UDtl+y/7ktFivgWvqw8dNSQeNWoSDLvQ1H/RN3aPXB9tBd4/FhyR4RDPGhsNIMsAn7g==}
 
-  cross-spawn@7.0.5:
-    resolution: {integrity: sha512-ZVJrKKYunU38/76t0RMOulHOnUcbU9GbpWKAOZ0mhjr7CX6FVrH+4FrAapSOekrgFQ3f/8gwMEuIft0aKq6Hug==}
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
   cssesc@3.0.0:
@@ -728,8 +728,8 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
-  tailwindcss@3.4.14:
-    resolution: {integrity: sha512-IcSvOcTRcUtQQ7ILQL5quRDg7Xs93PdJEk1ZLbhhvJc7uj/OAhYOnruEiwnGgBvUtaUAJ8/mhSw1o8L2jCiENA==}
+  tailwindcss@3.4.15:
+    resolution: {integrity: sha512-r4MeXnfBmSOuKUWmXe6h2CcyfzJCEk4F0pptO5jlnYSIViUkVmsawj80N5h2lO3gwcmSb4n3PuN+e+GC1Guylw==}
     engines: {node: '>=14.0.0'}
     hasBin: true
 
@@ -778,8 +778,8 @@ packages:
     resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
     engines: {node: '>=12'}
 
-  yaml@2.6.0:
-    resolution: {integrity: sha512-a6ae//JvKDEra2kdi1qzCyrJW/WZCgFi8ydDV+eXExl95t+5R+ijnqHJbz9tmMh8FUjx3iv2fCQ4dclAQlO2UQ==}
+  yaml@2.6.1:
+    resolution: {integrity: sha512-7r0XPzioN/Q9kXBro/XPnA6kznR73DHq+GXh5ON7ZozRO6aMjbmiBuKste2wslTFkC5d1dw0GooOCepZXJ2SAg==}
     engines: {node: '>= 14'}
     hasBin: true
 
@@ -1084,7 +1084,7 @@ snapshots:
 
   core-js@3.39.0: {}
 
-  cross-spawn@7.0.5:
+  cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
       shebang-command: 2.0.0
@@ -1126,7 +1126,7 @@ snapshots:
 
   foreground-child@3.3.0:
     dependencies:
-      cross-spawn: 7.0.5
+      cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
   fsevents@2.3.2:
@@ -1269,7 +1269,7 @@ snapshots:
   postcss-load-config@4.0.2(postcss@8.4.47):
     dependencies:
       lilconfig: 3.1.2
-      yaml: 2.6.0
+      yaml: 2.6.1
     optionalDependencies:
       postcss: 8.4.47
 
@@ -1368,7 +1368,7 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  tailwindcss@3.4.14:
+  tailwindcss@3.4.15:
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -1438,4 +1438,4 @@ snapshots:
       string-width: 5.1.2
       strip-ansi: 7.1.0
 
-  yaml@2.6.0: {}
+  yaml@2.6.1: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,12 +26,18 @@ importers:
       '@types/node':
         specifier: ^22.9.0
         version: 22.9.0
+      '@types/semver':
+        specifier: ^7.5.8
+        version: 7.5.8
       playwright:
         specifier: ^1.48.2
         version: 1.48.2
       postcss:
         specifier: ^8.4.47
         version: 8.4.47
+      semver:
+        specifier: ^7.6.3
+        version: 7.6.3
       simple-git-hooks:
         specifier: ^2.11.1
         version: 2.11.1
@@ -316,6 +322,9 @@ packages:
 
   '@types/node@22.9.0':
     resolution: {integrity: sha512-vuyHg81vvWA1Z1ELfvLko2c8f34gyA0zaic0+Rllc5lbCnbSyuvb2Oxpm6TAUAC/2xZN3QGqxBNggD1nNR2AfQ==}
+
+  '@types/semver@7.5.8':
+    resolution: {integrity: sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -669,6 +678,11 @@ packages:
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
+  semver@7.6.3:
+    resolution: {integrity: sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
@@ -1009,6 +1023,8 @@ snapshots:
     dependencies:
       undici-types: 6.19.8
 
+  '@types/semver@7.5.8': {}
+
   ansi-regex@5.0.1: {}
 
   ansi-regex@6.1.0: {}
@@ -1305,6 +1321,8 @@ snapshots:
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
+
+  semver@7.6.3: {}
 
   shebang-command@2.0.0:
     dependencies:

--- a/src/TailwindCSSRspackPlugin.ts
+++ b/src/TailwindCSSRspackPlugin.ts
@@ -300,7 +300,9 @@ class TailwindRspackPluginImpl {
 
   async #resolveTailwindCSSVersion(): Promise<string> {
     const require = createRequire(import.meta.url);
-    const pkgPath = require.resolve('tailwindcss/package.json');
+    const pkgPath = require.resolve('tailwindcss/package.json', {
+      paths: [this.compiler.context],
+    });
 
     const content = await readFile(pkgPath, 'utf-8');
 

--- a/src/TailwindCSSRspackPlugin.ts
+++ b/src/TailwindCSSRspackPlugin.ts
@@ -343,7 +343,7 @@ export default {
     // Otherwise, we provide an CJS configuration since TailwindCSS would always use `require`.
     return existsSync(userConfig)
       ? `\
-const config = require('${userConfig}')
+const config = require('${pathToFileURL(userConfig)}')
 module.exports = {
   ...config,
   content: ${content}

--- a/src/TailwindCSSRspackPlugin.ts
+++ b/src/TailwindCSSRspackPlugin.ts
@@ -349,7 +349,7 @@ export default {
       'tailwind.config.cjs',
       existsSync(userConfig)
         ? `\
-const config = require('${process.platform === 'win32' ? pathToFileURL(userConfig) : userConfig}')
+const config = require(${JSON.stringify(userConfig)})
 module.exports = {
   ...config,
   content: ${content}

--- a/test/basic/tailwind.config.js
+++ b/test/basic/tailwind.config.js
@@ -1,2 +1,0 @@
-/** @type {import('tailwindcss').Config} */
-export default {};

--- a/test/cjs/config/package.json
+++ b/test/cjs/config/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/test/cjs/config/tailwind.config.js
+++ b/test/cjs/config/tailwind.config.js
@@ -1,0 +1,2 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {};

--- a/test/cjs/index.test.ts
+++ b/test/cjs/index.test.ts
@@ -1,0 +1,99 @@
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { expect, test } from '@playwright/test';
+import { createRsbuild } from '@rsbuild/core';
+import { pluginTailwindCSS } from '../../src';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+test('should build with relative config', async ({ page }) => {
+  const rsbuild = await createRsbuild({
+    cwd: __dirname,
+    rsbuildConfig: {
+      plugins: [
+        pluginTailwindCSS({
+          config: './config/tailwind.config.js',
+        }),
+      ],
+    },
+  });
+
+  await rsbuild.build();
+  const { server, urls } = await rsbuild.preview();
+
+  await page.goto(urls[0]);
+
+  const display = await page.evaluate(() => {
+    const el = document.getElementById('test');
+
+    if (!el) {
+      throw new Error('#test not found');
+    }
+
+    return window.getComputedStyle(el).getPropertyValue('display');
+  });
+
+  expect(display).toBe('flex');
+
+  await server.close();
+});
+
+test('should build with absolute config', async ({ page }) => {
+  const rsbuild = await createRsbuild({
+    cwd: __dirname,
+    rsbuildConfig: {
+      plugins: [
+        pluginTailwindCSS({
+          config: resolve(__dirname, './config/tailwind.config.js'),
+        }),
+      ],
+    },
+  });
+
+  await rsbuild.build();
+  const { server, urls } = await rsbuild.preview();
+
+  await page.goto(urls[0]);
+
+  const display = await page.evaluate(() => {
+    const el = document.getElementById('test');
+
+    if (!el) {
+      throw new Error('#test not found');
+    }
+
+    return window.getComputedStyle(el).getPropertyValue('display');
+  });
+
+  expect(display).toBe('flex');
+
+  await server.close();
+});
+
+test('should build without tailwind.config.js', async ({ page }) => {
+  const rsbuild = await createRsbuild({
+    cwd: __dirname,
+    rsbuildConfig: {
+      plugins: [pluginTailwindCSS()],
+    },
+  });
+
+  await rsbuild.build();
+  const { server, urls } = await rsbuild.preview();
+
+  await page.goto(urls[0]);
+
+  const display = await page.evaluate(() => {
+    const el = document.getElementById('test');
+
+    if (!el) {
+      throw new Error('#test not found');
+    }
+
+    return window.getComputedStyle(el).getPropertyValue('display');
+  });
+
+  expect(display).toBe('flex');
+
+  await server.close();
+});

--- a/test/cjs/src/index.js
+++ b/test/cjs/src/index.js
@@ -1,0 +1,11 @@
+import 'tailwindcss/utilities.css';
+
+function className() {
+  return 'flex';
+}
+
+const root = document.getElementById('root');
+const element = document.createElement('div');
+element.id = 'test';
+element.className = className();
+root.appendChild(element);

--- a/test/config/index.test.ts
+++ b/test/config/index.test.ts
@@ -3,10 +3,16 @@ import { fileURLToPath } from 'node:url';
 import { expect, test } from '@playwright/test';
 import { createRsbuild } from '@rsbuild/core';
 import { pluginTailwindCSS } from '../../src';
+import { supportESM } from '../helper';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 test('should build with relative config', async ({ page }) => {
+  test.skip(
+    !supportESM(),
+    'Skip since the tailwindcss version does not support ESM configuration',
+  );
+
   const rsbuild = await createRsbuild({
     cwd: __dirname,
     rsbuildConfig: {
@@ -39,6 +45,11 @@ test('should build with relative config', async ({ page }) => {
 });
 
 test('should build with absolute config', async ({ page }) => {
+  test.skip(
+    !supportESM(),
+    'Skip since the tailwindcss version does not support ESM configuration',
+  );
+
   const rsbuild = await createRsbuild({
     cwd: __dirname,
     rsbuildConfig: {

--- a/test/helper.ts
+++ b/test/helper.ts
@@ -1,3 +1,6 @@
+import satisfies from 'semver/functions/satisfies.js';
+import pkg from 'tailwindcss/package.json' with { type: 'json' };
+
 const portMap = new Map();
 
 export function getRandomPort(
@@ -11,4 +14,13 @@ export function getRandomPort(
     }
     port++;
   }
+}
+
+export function supportESM(): boolean {
+  // Tailwind CSS support using ESM configuration in v3.3.0
+  // See:
+  //   - https://github.com/tailwindlabs/tailwindcss/releases/tag/v3.3.0
+  //   - https://github.com/tailwindlabs/tailwindcss/pull/10785
+  //   - https://github.com/rspack-contrib/rsbuild-plugin-tailwindcss/issues/18
+  return satisfies(pkg.version, '^3.3.0');
 }

--- a/test/multi-entries/tailwind.config.js
+++ b/test/multi-entries/tailwind.config.js
@@ -1,2 +1,0 @@
-/** @type {import('tailwindcss').Config} */
-export default {};


### PR DESCRIPTION
### Summary

Support Tailwind CSS v3.1 and Tailwind CSS v3.2.

---

### Details

Since Tailwind CSS support using ESM configuration in V3.3, we need to use CJS configuration before that.

As mentioned in https://github.com/rspack-contrib/rsbuild-plugin-tailwindcss/issues/7#issuecomment-2472754144, we use `readFile` + `require.resolve` to get the version of `tailwindcss/package.json`.

- If `satisfies(version, ^3.3.0)`, we will generate ESM configuration to support both ESM and CJS.
- Else, we generate CJS configuration.

---

### Test plan

We setup two new entries in the testing matrix

- tailwindcss v3.1.0 with Ubuntu
- tailwindcss v3.1.0 with Windows

As you can see, the test is failing at [0e05c6a](https://github.com/rspack-contrib/rsbuild-plugin-tailwindcss/pull/21/commits/0e05c6a1d04d47f40c580bf3118419a8c3b69bdf).

And after the fix is landed in [e783415](https://github.com/rspack-contrib/rsbuild-plugin-tailwindcss/pull/21/commits/e783415dcee20bd949400d68a4995b98515b8ed8), the test for old tailwindcss is passing.

---

### Related links

close: #18 

- Tailwind CSS v3.3:
  - https://github.com/tailwindlabs/tailwindcss/releases/tag/v3.3.0
  - https://github.com/tailwindlabs/tailwindcss/pull/10785
- Tailwind CSS v3.2
  - https://github.com/tailwindlabs/tailwindcss/releases/tag/v3.2.0
- Tailwind CSS v3.1
  - https://github.com/tailwindlabs/tailwindcss/releases/tag/v3.1.0