### PR TITLE
ci: reduce playwright install time

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
           cache: "pnpm"
 
       - name: Install Dependencies
-        run: pnpm install && npx playwright install
+        run: pnpm install && npx playwright install chromium
 
       - name: Run Test
         run: pnpm run test


### PR DESCRIPTION
Reduce playwright install time, only `chromium` is required.

See: https://github.com/web-infra-dev/rsbuild/pull/3995