### PR TITLE
fix!: change peer of tailwindcss to `^3.1.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "peerDependencies": {
     "@rsbuild/core": "^1.1.0",
-    "tailwindcss": "^3"
+    "tailwindcss": "^3.1.0"
   },
   "peerDependenciesMeta": {
     "@rsbuild/core": {


### PR DESCRIPTION
>[!WARNING]
>
> Please note that this is a **BREAKING CHANGE**.

As the test result of #21 shows that we does not support Tailwind CSS v3.0.x. Since it does not have `config` option yet.

And v3.1.x and v3.2.y will be supported after #21 is merged.