### PR TITLE
chore: update playground

### DIFF
--- a/playground/package.json
+++ b/playground/package.json
@@ -2,6 +2,9 @@
   "name": "playground",
   "private": true,
   "version": "0.0.0",
+  "devDependencies": {
+    "rsbuild-plugin-tailwindcss": "workspace:*"
+  },
   "scripts": {
     "dev": "npx rsbuild dev",
     "build": "npx rsbuild build"

--- a/playground/rsbuild.config.ts
+++ b/playground/rsbuild.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from '@rsbuild/core';
-import { pluginTailwindCSS } from '../src';
+import { pluginTailwindCSS } from 'rsbuild-plugin-tailwindcss';
 
 export default defineConfig({
   plugins: [pluginTailwindCSS()],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,7 +42,11 @@ importers:
         specifier: ^5.6.3
         version: 5.6.3
 
-  playground: {}
+  playground:
+    devDependencies:
+      rsbuild-plugin-tailwindcss:
+        specifier: workspace:*
+        version: link:..
 
 packages:
 


### PR DESCRIPTION
Use `workspace:*` to avoid build error.