### PR TITLE
fix: other postcss plugins should not run before tailwindcss

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Pnpm
-        run: npm i -g corepack@latest && corepack enable
+        run: npm i -g corepack@latest --force && corepack enable
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Pnpm
-        run: corepack enable
+        run: npm i -g corepack@latest && corepack enable
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Pnpm
-        run: npm i -g corepack@latest && corepack enable
+        run: npm i -g corepack@latest --force && corepack enable
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Pnpm
-        run: corepack enable
+        run: npm i -g corepack@latest && corepack enable
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# CHANGELOG
+
+## 0.2.0
+
+- Fixed bug that other postcss plugins should not run before tailwindcss.

--- a/src/TailwindCSSRspackPlugin.ts
+++ b/src/TailwindCSSRspackPlugin.ts
@@ -260,12 +260,12 @@ class TailwindRspackPluginImpl {
               ]);
 
               const processor = postcss([
-                ...(options.postcssOptions?.plugins ?? []),
                 // We use a config path to avoid performance issue of TailwindCSS
                 // See: https://github.com/tailwindlabs/tailwindcss/issues/14229
                 tailwindcss({
                   config: configPath,
                 }),
+                ...(options.postcssOptions?.plugins ?? []),
               ]);
 
               TailwindRspackPluginImpl.#postcssProcessorCache.set(entryName, [


### PR DESCRIPTION
Maybe like the example in [tailwindcss documentation](https://v3.tailwindcss.com/docs/installation/using-postcss), the tailwindcss postcss plugin should in the first place: 
```js
module.exports = {
  plugins: {
    tailwindcss: {},
    autoprefixer: {},
  }
}
```