### PR TITLE
fix: avoid unexpected cache hits

### DIFF
--- a/src/TailwindCSSRspackPlugin.ts
+++ b/src/TailwindCSSRspackPlugin.ts
@@ -179,7 +179,7 @@ export type { TailwindRspackPluginOptions };
 class TailwindRspackPluginImpl {
   name = 'TailwindRspackPlugin';
 
-  static #postcssProcessorCache = new Map<
+  postcssProcessorCache = new Map<
     /** entryName */ string,
     [entryModules: ReadonlySet<string>, Processor]
   >();
@@ -209,8 +209,7 @@ class TailwindRspackPluginImpl {
                 return;
               }
 
-              const cache =
-                TailwindRspackPluginImpl.#postcssProcessorCache.get(entryName);
+              const cache = this.postcssProcessorCache.get(entryName);
               if (compiler.modifiedFiles?.size && cache) {
                 const [cachedEntryModules, cachedPostcssProcessor] = cache;
                 if (isSubsetOf(compiler.modifiedFiles, cachedEntryModules)) {
@@ -268,7 +267,7 @@ class TailwindRspackPluginImpl {
                 ...(options.postcssOptions?.plugins ?? []),
               ]);
 
-              TailwindRspackPluginImpl.#postcssProcessorCache.set(entryName, [
+              this.postcssProcessorCache.set(entryName, [
                 entryModules,
                 processor,
               ]);


### PR DESCRIPTION
Use instance `postcssProcessorCache` attribute instead of static `postcssProcessorCache` in `TailwindRspackPluginImpl` class. Avoid unexpected cache hits due to import cache when multiple builds.