### PR TITLE
chore: move pnpm-related config to `pnpm-workspace.yaml`

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,6 +1,1 @@
-# Disable the default public-hoist-pattern(*-eslint-*, *-prettier-*)
-public-hoist-pattern=
-hoist-workspace-packages=true
-strict-peer-dependencies=true
-engine-strict=true
 registry=https://registry.npmjs.org/

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,8 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+pnpmfileChecksum: sha256-/xhzNOuu2gnHZ9xSXg2Whi1pXgoDOLRXuVQKnoPEjMY=
+
 importers:
 
   .:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,13 @@
 packages:
-  - 'playground'
+  - playground
+
+configDependencies:
+  '@pnpm/plugin-better-defaults': 0.1.0+sha512-aWj7Jv9NcNs/OoazrxP6QspLgKRZ2PHj6wPris6ZCEqmXw+Z8zK59KLzl9NBFGRCO4PNA9pwDWLu+8N3NiqUAQ==
+
+engineStrict: true
+
+hoistWorkspacePackages: true
+
+publicHoistPattern: []
+
+strictPeerDependencies: true


### PR DESCRIPTION
Move pnpm-related configurations from `.npmrc` to `pnpm-workspace.yaml`.

This would resolve the warning during publishing:

```
. prepare: npm warn Unknown env config "verify-deps-before-run". This will stop working in the next major version of npm.
. prepare: npm warn Unknown env config "strict-peer-dependencies". This will stop working in the next major version of npm.
. prepare: npm warn Unknown env config "_jsr-registry". This will stop working in the next major version of npm.
. prepare: npm warn Unknown env config "hoist-workspace-packages". This will stop working in the next major version of npm.
. prepare: npm warn Unknown project config "public-hoist-pattern". This will stop working in the next major version of npm.
. prepare: npm warn Unknown project config "hoist-workspace-packages". This will stop working in the next major version of npm.
. prepare: npm warn Unknown project config "strict-peer-dependencies". This will stop working in the next major version of npm.
```

Also, integrate with https://github.com/pnpm/plugin-better-defaults.