### PR TITLE
fix: skip cache cleanup during development

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -199,6 +199,10 @@ ${code}`;
     });
 
     api.onAfterBuild(() => {
+      if (api.context.action === 'dev') {
+        return;
+      }
+
       cleanupCache({
         config: finalConfigPath,
         theme,


### PR DESCRIPTION
## Summary
- Skip `cleanupCache` when `api.context.action === 'dev'` to retain cache during dev server runs.