### PR TITLE
fix: escape dot in virtual utilities RegExp

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -188,7 +188,14 @@ ${code}`;
     api.modifyBundlerChain((chain) => {
       chain.module
         .rule('tailwindcss')
-        .resource(new RegExp(VIRTUAL_UTILITIES_ID.replace(/\//g, '[\\\\/]')))
+        .resource(
+          new RegExp(
+            VIRTUAL_UTILITIES_ID.replace(/\//g, '[\\\\/]').replace(
+              /\./g,
+              '\\.',
+            ),
+          ),
+        )
         .use('tailwindcss')
         .loader(require.resolve('./loader'))
         .options({


### PR DESCRIPTION
## Summary
- Escape the dot character in `VIRTUAL_UTILITIES_ID` when constructing the `RegExp` to prevent unintended matching.